### PR TITLE
Mark direct conversation as read after opening it

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -169,6 +169,11 @@
   top: 6px;
   right: 0px;
 }
+#auth-bar .has-unread-messages {
+  font-size: 12px;
+  top: -8px;
+  right: -8px;
+}
 
 #sign-out-button {
   background-color: white !important;

--- a/src/DB.tsx
+++ b/src/DB.tsx
@@ -376,6 +376,18 @@ export const useDirectMessage = (dialogId: string) => {
     [dialogInfo, dialogId, ref, me]
   );
 
+  const updateLastMessageReadByMe = useCallback(async () => {
+    if (!me) throw new Error('Not authenticated');
+
+    if (!dialogInfo) {
+      return;
+    }
+
+    return ref.update({
+      [`lastReadBy.${me.uid}`]: dialogInfo.lastMsgId,
+    });
+  }, [dialogInfo, ref, me]);
+
   useEffect(
     () =>
       ref.onSnapshot(
@@ -416,7 +428,7 @@ export const useDirectMessage = (dialogId: string) => {
       );
   }, [ref, dialogId, dialogInfo, retryCounter]);
 
-  return { info: dialogInfo, messages, postMessage };
+  return { info: dialogInfo, messages, postMessage, updateLastMessageReadByMe };
 };
 
 export const useMyDirectMessages = () => {

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -57,7 +57,7 @@ export const AuthBar: React.FC = () => {
                 {unreadDialogs > 0 && (
                   <Icon
                     corner="top right"
-                    size="small"
+                    className="has-unread-messages"
                     name="mail"
                     color="red"
                   />

--- a/src/components/DirectMessage.tsx
+++ b/src/components/DirectMessage.tsx
@@ -162,7 +162,7 @@ const DialogInfoItem: React.FC<{ info: DirectMessageInfo; me: AuthUser }> = ({
             )}`}
             className={unread ? 'unread' : 'read'}
           >
-            {peer?.name}
+            {peer?.name || 'Anonymous'}
           </Link>
         </List.Header>
         {dayjs(updated).fromNow()}

--- a/src/components/DirectMessage.tsx
+++ b/src/components/DirectMessage.tsx
@@ -15,7 +15,7 @@ import {
 } from '../types';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { directMessageId } from '../utils';
+import { directMessageId, reportError } from '../utils';
 dayjs.extend(relativeTime);
 
 const SingleMessage: React.FC<{
@@ -39,7 +39,12 @@ const SingleMessage: React.FC<{
 
 const useDirectMessageView = () => {
   const { dmKey = '' } = useParams<{ dmKey: string }>();
-  const { info, messages, postMessage } = useDirectMessage(dmKey);
+  const {
+    info,
+    messages,
+    postMessage,
+    updateLastMessageReadByMe,
+  } = useDirectMessage(dmKey);
   console.debug('DirectMessage', dmKey, { info, messages });
   const me = useAuth();
   const ids = dmKey.split('-');
@@ -51,6 +56,14 @@ const useDirectMessageView = () => {
   useEffect(() => {
     refMessagesBottom.current?.scrollIntoView();
   }, [messages]);
+
+  useEffect(() => {
+    // basically marking conversation till current last message as read
+    // TODO make it smarter by actually tracing the last message seen on screen
+    if (info && me && info.lastMsgId !== info.lastReadBy[me.uid]) {
+      updateLastMessageReadByMe().catch((err) => reportError(err, true));
+    }
+  }, [info]);
 
   const [message, setMessage] = useState('');
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
-export const reportError = (err: Error) => {
+export const reportError = (err: Error, silent = false) => {
   console.error(err);
-  alert(err.message);
+  if (!silent) alert(err.message);
 };
 
 export const directMessageId = (me: string, other: string) => {


### PR DESCRIPTION
Mark direct conversation as read after opening it. It sets the lastReadBy[currentUser] to the latest message.

Few more cosmetic improvements here - more visible unread message indicator in control bar, fix for empty record in direct messages list if peer has not filled the nickname yet.

Resolves #24 