### PR TITLE
Embed the platform into 3rd party websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,51 @@
 
 This project is home for number of location-based local community services - moderated by the community.
 
-More details about project ideas and structure can be found in the [Wiki](https://github.com/dmitry-yudakov/community-map/wiki)
+More details about project ideas and structure can be found in the [Wiki](https://github.com/opencommunitymap/communitymap-ui/wiki)
 
 ## Slack workspace
 
 Feel free to [join our Slack space](https://join.slack.com/t/opencommunitymap/shared_invite/zt-e7hqo2zo-rbeP~IoF0pPkAEsa0B7lcw) and ask questions or share your ideas with us!
+
+## Embedding into 3rd party site
+
+It's possible to embed the map into 3rd party site. You need to use the _appId_ we'll provide you.
+
+```
+https://communitymap.online/embed/?appId=<your-app-id>
+```
+
+Example:
+
+```
+<iframe
+  src="https://communitymap.online/embed?appId=Test42"
+  allow="geolocation"
+  style="border-width: 0;"
+  width="100%"
+  height="850"
+></iframe>
+```
+
+Currently you can filter to show only your objects on the map using optional _filterOrigin_ query parameter. If it's missing, all types of objects are shown.
+
+Optional _centerLat_ and _centerLng_ parameters define the default coordinates to the map.
+
+Optional _canAdd_ allows to hide UI elements for adding objects from this view. If you need to add them your own way, hide them and use the [API](#API).
+
+```
+<iframe
+  src="https://communitymap.online/embed?appId=Test42&filterOrigin=Test42&centerLat=43.123&centerLng=24.122&canAdd=false"
+  allow="geolocation"
+  style="border-width: 0;"
+  width="100%"
+  height="850"
+></iframe>
+```
+
+## API
+
+Check out the [API documentation](https://github.com/opencommunitymap/communitymap-cloud-functions/blob/master/docs/API.md)
 
 ## Development
 
@@ -30,7 +70,7 @@ The maps with show 'For development purposes only' watermark all over the map.
 
 To fix that create _.env_ file and fill in your Google Maps Key.
 
-## Configure with different
+## Configure with different Firebase project
 
 ```
 cp .env.sample .env

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -41,6 +41,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "objects",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "origin",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "loc",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "firebase": "^7.14.2",
     "firebaseui": "^4.5.0",
     "google-map-react": "^1.1.7",
+    "query-string": "^6.12.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,17 @@ export interface MapParams {
   maxLng: number;
 }
 
+export interface EmbedParams {
+  appId: string;
+}
+
+export interface InitialAppParams extends Partial<EmbedParams> {
+  filterOrigin?: string;
+  canAdd?: boolean;
+  centerLat?: number;
+  centerLng?: number;
+}
+
 export interface UserProfile {
   id: string;
   created?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9082,6 +9082,15 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.12.1:
+  version "6.12.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.12.1.tgz#2ae4d272db4fba267141665374e49a1de09e8a7c"
+  integrity sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10209,6 +10218,11 @@ spdy@^4.0.1:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -10315,6 +10329,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The 3rd party can define its appId that is stored in our DB - it will be used as origin when adding objects from the embedded view.
Later it could be used to control the access for the embedding.

Optional filterOrigin allows to load only objects of given origin (aka appId).

Optional centerLat/centerLng allow to set default center coordinates - both embeddable and normal view.

Optional canAdd defines whether to hide the adding controls.