### PR TITLE
feat(ci): include app environment setup step in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - next
-      - production
+      - prod
 
 jobs:
   deploy:
@@ -33,6 +33,23 @@ jobs:
         run: |
           yarn install --frozen-lockfile
 
+      - name: Expose Application Environment Variables
+        env:
+          MASTER_REACT_APP_GOOGLE_API_KEY: ${{ secrets.MASTER_REACT_APP_GOOGLE_API_KEY }}
+          NEXT_REACT_APP_GOOGLE_API_KEY: ${{ secrets.NEXT_REACT_APP_GOOGLE_API_KEY }}
+          PROD_REACT_APP_GOOGLE_API_KEY: ${{ secrets.PROD_REACT_APP_GOOGLE_API_KEY }}
+        run: |
+          gitBranch=${GITHUB_REF##*/}
+          branchPrefix=$(echo $gitBranch | tr a-z A-Z | tr - _)
+          branchApiKeyName="${branchPrefix}_SERVICE_ACCOUNT"
+          branchApiKey=$(eval echo \$${branchApiKeyName})
+          if [[ -z "${branchApiKey}" ]]; then
+            echo Branch Google API Key not found, exiting
+            exit 1
+          fi
+          # Expose variable to environment for later steps
+          echo "::set-env name=REACT_APP_GOOGLE_API_KEY::$branchApiKey"
+
       - name: Verify App
         run: |
           yarn build
@@ -46,12 +63,12 @@ jobs:
           $(yarn bin)/firebase-ci deploy -s
 
       - name: Check if version has been updated
-        if: github.ref == 'refs/heads/production'
+        if: github.ref == 'refs/heads/prod'
         id: check
         uses: EndBug/version-check@v1
 
       - name: Create Release
-        if: github.ref == 'refs/heads/production' && steps.check.outputs.changed == 'true'
+        if: github.ref == 'refs/heads/prod' && steps.check.outputs.changed == 'true'
         id: create_release
         uses: actions/create-release@latest
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,10 +39,15 @@ jobs:
           NEXT_REACT_APP_GOOGLE_API_KEY: ${{ secrets.NEXT_REACT_APP_GOOGLE_API_KEY }}
           PROD_REACT_APP_GOOGLE_API_KEY: ${{ secrets.PROD_REACT_APP_GOOGLE_API_KEY }}
         run: |
+          # Get branch name from last section of ref
           gitBranch=${GITHUB_REF##*/}
+          # Uppercase branch name and replace "-" with "_"
           branchPrefix=$(echo $gitBranch | tr a-z A-Z | tr - _)
-          branchApiKeyName="${branchPrefix}_SERVICE_ACCOUNT"
+          # Create env variable name including branch
+          branchApiKeyName="${branchPrefix}_REACT_APP_GOOGLE_API_KEY"
+          # Evaluate name variable to get variables value
           branchApiKey=$(eval echo \$${branchApiKeyName})
+          # Exit if branch API key is not found
           if [[ -z "${branchApiKey}" ]]; then
             echo Branch Google API Key not found, exiting
             exit 1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,16 +29,22 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Expose Application Environment Variables
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
           MASTER_REACT_APP_GOOGLE_API_KEY: ${{ secrets.MASTER_REACT_APP_GOOGLE_API_KEY }}
           NEXT_REACT_APP_GOOGLE_API_KEY: ${{ secrets.NEXT_REACT_APP_GOOGLE_API_KEY }}
           PROD_REACT_APP_GOOGLE_API_KEY: ${{ secrets.PROD_REACT_APP_GOOGLE_API_KEY }}
         run: |
+          # Get branch name from last section of ref
           gitBranch=${GITHUB_REF##*/}
+          # Uppercase branch name and replace "-" with "_"
           branchPrefix=$(echo $gitBranch | tr a-z A-Z | tr - _)
-          branchApiKeyName="${branchPrefix}_SERVICE_ACCOUNT"
+          # Create env variable name including branch
+          branchApiKeyName="${branchPrefix}_REACT_APP_GOOGLE_API_KEY"
+          # Evaluate name variable to get variables value
           branchApiKey=$(eval echo \$${branchApiKeyName})
+          # Set value if it exists, otherwise fallback to default
           if [[ ! -z "${branchApiKey}" ]]; then
             echo Using Google API Key for branch \"$gitBranch\"
             googleApiKey=$branchApiKey
@@ -48,6 +54,13 @@ jobs:
           fi
           # Expose variable to environment for later steps
           echo "::set-env name=REACT_APP_GOOGLE_API_KEY::$googleApiKey"
+
+        # NOTE: This stage runs if build is a fork (since secrets do not exist)
+      - name: Expose Application Environment Variables (for fork)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+            # Expose variable to environment for later steps
+            echo "::set-env name=REACT_APP_GOOGLE_API_KEY::asdf"
 
       - name: Verify App
         # TODO: Add calling of lint command once it exists

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,6 +28,27 @@ jobs:
         run: |
           yarn install --frozen-lockfile
 
+      - name: Expose Application Environment Variables
+        env:
+          REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          MASTER_REACT_APP_GOOGLE_API_KEY: ${{ secrets.MASTER_REACT_APP_GOOGLE_API_KEY }}
+          NEXT_REACT_APP_GOOGLE_API_KEY: ${{ secrets.NEXT_REACT_APP_GOOGLE_API_KEY }}
+          PROD_REACT_APP_GOOGLE_API_KEY: ${{ secrets.PROD_REACT_APP_GOOGLE_API_KEY }}
+        run: |
+          gitBranch=${GITHUB_REF##*/}
+          branchPrefix=$(echo $gitBranch | tr a-z A-Z | tr - _)
+          branchApiKeyName="${branchPrefix}_SERVICE_ACCOUNT"
+          branchApiKey=$(eval echo \$${branchApiKeyName})
+          if [[ ! -z "${branchApiKey}" ]]; then
+            echo Using Google API Key for branch \"$gitBranch\"
+            googleApiKey=$branchApiKey
+          else
+            echo Falling back to default Google API Key
+            googleApiKey=$REACT_APP_GOOGLE_API_KEY
+          fi
+          # Expose variable to environment for later steps
+          echo "::set-env name=REACT_APP_GOOGLE_API_KEY::$googleApiKey"
+
       - name: Verify App
         # TODO: Add calling of lint command once it exists
         run: |


### PR DESCRIPTION
* Adds a step for exposing application environment variables. The step manages loading env variables based on branch name so that `master` loads `MASTER_REACT_APP_GOOGLE_API_KEY` - doing this makes it match environments set up by the deploy logic 
* Adds a step for setting app variables in case of a PR from a fork - this is needed since secrets are not available in forks for security

We will want to set the following secrets in CI:
```
MASTER_REACT_APP_GOOGLE_API_KEY
PROD_REACT_APP_GOOGLE_API_KEY
```