### PR TITLE
Setup for production deploy

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -2,7 +2,7 @@
   "projects": {
     "dev": "community-map-dev",
     "master": "community-map-dev",
-    "production": "community-map-dev",
+    "prod": "communitymap42",
     "default": "community-map-dev"
   }
 }

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import logo from '../logo.svg';
 
-export const SplashScreen = () => {
+export const SplashScreen: React.FC<{ showLogo?: boolean }> = ({
+  showLogo = true,
+}) => {
   return (
     <div className="splash">
       <header className="splash-header">
-        <img src={logo} className="splash-logo" alt="logo" />
+        {showLogo && <img src={logo} className="splash-logo" alt="logo" />}
       </header>
     </div>
   );


### PR DESCRIPTION
Reworked the way firebase config is taken when deployed.

For development env the old way is used with loading local _firebaseConfig.ts_ and using it to initialize Firebase app.

For production env I'm using the way described in [Firebase Docs](https://firebase.google.com/docs/hosting/reserved-urls?authuser=0#sdk_auto-configuration) fetching config from _/__/firebase/init.json_.

@prescottprue, could you take a look and share your opinion? I tried to find a more elegant way but couldn't.