### PR TITLE
fix(react-sdk): null value for profile and navigation widget argument…

### DIFF
--- a/react-sdk/src/modules/CommunityMap.tsx
+++ b/react-sdk/src/modules/CommunityMap.tsx
@@ -219,8 +219,10 @@ const CommunityMapImpl: React.FC<CommunityMapProps> = ({
           )}
         </Modal.Content>
       </Modal>
-      {profileWidget || <ProfileWidget />}
-      {navigationWidget || (
+      {profileWidget !== undefined ? profileWidget : <ProfileWidget />}
+      {navigationWidget !== undefined ? (
+        navigationWidget
+      ) : (
         <NavigationWidget
           onChangePosition={(loc) => setAutodetectedCenter(loc)}
         />


### PR DESCRIPTION
…s should hide them

Default components for both profile/navigation widgets were shown for both undefined and null values - only undefined should trigger using default, while null should be the way to hide the widgets.